### PR TITLE
chore: revisions to accomodate increased provider versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ mock-user-data.log
 # Ignore Terraform lock files, as we want to test the Terraform code in these repos with the latest provider
 # versions.
 .terraform.lock.hcl
+
+# Ignore VSCode personalization config
+.vscode/settings.json

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -8,6 +8,18 @@ terraform {
   # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
   # forwards compatible with 1.0.x code.
   required_version = ">= 1.4.6"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.73.1"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.73.1"
+    }
+  }
+
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -104,11 +104,6 @@ resource "google_container_cluster" "cluster" {
     enabled = var.enable_vertical_pod_autoscaling
   }
 
-  master_auth {
-    username = var.basic_auth_username
-    password = var.basic_auth_password
-  }
-
   dynamic "master_authorized_networks_config" {
     for_each = var.master_authorized_networks_config
     content {

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -7,7 +7,7 @@ terraform {
   # This module is now only being tested with Terraform 1.0.x. However, to make upgrading easier, we are setting
   # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
   # forwards compatible with 1.0.x code.
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.4.6"
 }
 
 locals {

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -10,12 +10,6 @@ terraform {
   required_version = ">= 1.4.6"
 }
 
-locals {
-  workload_identity_config = !var.enable_workload_identity ? [] : var.identity_namespace == null ? [{
-    identity_namespace = "${var.project}.svc.id.goog" }] : [{ identity_namespace = var.identity_namespace
-  }]
-}
-
 # ---------------------------------------------------------------------------------------------------------------------
 # Create the GKE Cluster
 # We want to make a cluster with no node pools, and manage them all with the fine-grained google_container_node_pool resource
@@ -151,14 +145,6 @@ resource "google_container_cluster" "cluster" {
     content {
       state    = "ENCRYPTED"
       key_name = database_encryption.value
-    }
-  }
-
-  dynamic "workload_identity_config" {
-    for_each = local.workload_identity_config
-
-    content {
-      identity_namespace = workload_identity_config.value.identity_namespace
     }
   }
 

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -215,15 +215,3 @@ variable "services_secondary_range_name" {
   type        = string
   default     = null
 }
-
-variable "enable_workload_identity" {
-  description = "Enable Workload Identity on the cluster"
-  default     = false
-  type        = bool
-}
-
-variable "identity_namespace" {
-  description = "Workload Identity Namespace. Default sets project based namespace [project_id].svc.id.goog"
-  default     = null
-  type        = string
-}


### PR DESCRIPTION
Addresses [this notion issue](https://www.notion.so/buttoninc/Update-k8s-terraform-to-v4-67-0-or-later-2d0771acb02e4310813745d329b86f14?pvs=4). This PR updates terraform providers to their latest version. This allows us to make use of some newer features within our definitions of our infrastructure.  

## Changes

- Updates required providers within the module. 
- Removed deprecated attributes. 
- Disabled a new default monitoring config. 

## Notes

Marked this with tag `v0.11.0-b` as we have not done a thorough scan of any new or changed features to the providers versus the functionality of the module. The primary focus of the PR covers getting it running without errors. 